### PR TITLE
Feature/texture double allocation fix + retina display fix on iphone6 & +

### DIFF
--- a/src/moai-ios/host.mm
+++ b/src/moai-ios/host.mm
@@ -43,7 +43,7 @@ void AKUIosContextInitialize () {
 	environment.SetValue ( MOAI_ENV_devName,				[[ UIDevice currentDevice ].name UTF8String ] );
 	environment.SetValue ( MOAI_ENV_devModel,				[[ UIDevice currentDevice ].model UTF8String ] );
 	environment.SetValue ( MOAI_ENV_horizontalResolution,	[[ UIScreen mainScreen ] bounds ].size.width * [[ UIScreen mainScreen ] scale ] );	
-	environment.SetValue ( MOAI_ENV_iosRetinaDisplay,		[[ UIScreen mainScreen ] scale ] == 2.0 );
+	environment.SetValue ( MOAI_ENV_iosRetinaDisplay,		[[ UIScreen mainScreen ] scale ] >= 2.0 );
 	environment.SetValue ( MOAI_ENV_languageCode,			[[[ NSLocale currentLocale ] objectForKey: NSLocaleLanguageCode ] UTF8String ]);
 	environment.SetValue ( MOAI_ENV_osBrand,				"iOS" );
 	environment.SetValue ( MOAI_ENV_osVersion,				[[ UIDevice currentDevice ].systemVersion UTF8String ]);

--- a/src/moai-sim/MOAITexture.cpp
+++ b/src/moai-sim/MOAITexture.cpp
@@ -311,6 +311,9 @@ void MOAITexture::OnCPUDestroy () {
 	// the image and/or buffer
 	if ( this->HasReloader () || this->mFilename.size ()) {
 		
+		// force cleanup right away - the image is now in OpenGL, why keep it around until the next GC?
+		if (this->mImage)
+			this->mImage->Clear();
 		this->mImage.Set ( *this, 0 );
 		
 		if ( this->mTextureData ) {


### PR DESCRIPTION
In the current code, the Image is Cleared at some point on a garbage collect call, so technically it's not a leak.

The issue is that we don't run GC that often, and for a scene with a *lot* of assets, we end up allocating twice as much memory as needed. On some devices, this cause the OS to just kill the app, while clearing this image once it's been handed to the GPU prevents that. 

I feel this is cleaner.